### PR TITLE
Resourcenames

### DIFF
--- a/Jenkinsfile.openshift
+++ b/Jenkinsfile.openshift
@@ -1,4 +1,4 @@
-library 'pipeline-library@tiller-namespace'
+library 'pipeline-library'
 
 pipeline {
     agent {

--- a/Jenkinsfile.openshift
+++ b/Jenkinsfile.openshift
@@ -1,4 +1,4 @@
-library 'pipeline-library'
+library 'pipeline-library@tiller-namespace'
 
 pipeline {
     agent {

--- a/charts/sample-app-api/templates/deployment.yaml
+++ b/charts/sample-app-api/templates/deployment.yaml
@@ -1,3 +1,4 @@
+gndn
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/charts/sample-app-api/templates/deployment.yaml
+++ b/charts/sample-app-api/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ .Chart.Name }}
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/charts/sample-app-api/templates/deployment.yaml
+++ b/charts/sample-app-api/templates/deployment.yaml
@@ -1,4 +1,3 @@
-gndn
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/charts/sample-app-api/templates/deployment.yaml
+++ b/charts/sample-app-api/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ .Release.Name }}
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/charts/sample-app-api/templates/route.yaml
+++ b/charts/sample-app-api/templates/route.yaml
@@ -14,5 +14,9 @@ spec:
   {{- end }}
   to:
     kind: Service
-    name: {{ .Values.service.name }}
+    {{- if .Values.service.name }}
+      name: {{ .Values.service.name }}
+    {{- else }}
+      name: {{ .Release.Name }}
+    {{- end }}
 {{- end }}

--- a/charts/sample-app-api/templates/route.yaml
+++ b/charts/sample-app-api/templates/route.yaml
@@ -17,6 +17,6 @@ spec:
     {{- if .Values.service.name }}
       name: {{ .Values.service.name }}
     {{- else }}
-    name: {{ .Release.Name }}
+      name: {{ .Release.Name }}
     {{- end }}
 {{- end }}

--- a/charts/sample-app-api/templates/route.yaml
+++ b/charts/sample-app-api/templates/route.yaml
@@ -15,7 +15,7 @@ spec:
   to:
     kind: Service
     {{- if .Values.service.name }}
-    name: {{ .Values.service.name }}
+      name: {{ .Values.service.name }}
     {{- else }}
     name: {{ .Release.Name }}
     {{- end }}

--- a/charts/sample-app-api/templates/route.yaml
+++ b/charts/sample-app-api/templates/route.yaml
@@ -2,7 +2,7 @@
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ .Chart.Name }}
   annotations:
     description: OpenShift route for application's http service
   labels:

--- a/charts/sample-app-api/templates/route.yaml
+++ b/charts/sample-app-api/templates/route.yaml
@@ -15,8 +15,8 @@ spec:
   to:
     kind: Service
     {{- if .Values.service.name }}
-      name: {{ .Values.service.name }}
+    name: {{ .Values.service.name }}
     {{- else }}
-      name: {{ .Release.Name }}
+    name: {{ .Release.Name }}
     {{- end }}
 {{- end }}

--- a/charts/sample-app-api/templates/route.yaml
+++ b/charts/sample-app-api/templates/route.yaml
@@ -2,7 +2,7 @@
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ .Release.Name }}
   annotations:
     description: OpenShift route for application's http service
   labels:

--- a/charts/sample-app-api/templates/service.yaml
+++ b/charts/sample-app-api/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
 {{- if .Values.service.name }}
   name: {{ .Values.service.name }}
 {{- else }}
-  name: {{ template "fullname" . }}
+  name: {{ .Chart.Name }}
 {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/charts/sample-app-api/templates/service.yaml
+++ b/charts/sample-app-api/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
 {{- if .Values.service.name }}
   name: {{ .Values.service.name }}
 {{- else }}
-  name: {{ .Release.Name }}
+  name: {{ .Chart.Name }}
 {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/charts/sample-app-api/templates/service.yaml
+++ b/charts/sample-app-api/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
 {{- if .Values.service.name }}
   name: {{ .Values.service.name }}
 {{- else }}
-  name: {{ .Chart.Name }}
+  name: {{ .Release.Name }}
 {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/charts/sample-app-api/values.yaml
+++ b/charts/sample-app-api/values.yaml
@@ -7,7 +7,6 @@ image:
   tag: dev
   pullPolicy: IfNotPresent
 service:
-  name: sample-app-api
   type: ClusterIP
   externalPort: 80
   internalPort: 8080


### PR DESCRIPTION
use release name for kubernetes resources instead of template name so we don't get conflicts when deploying branch builds 

helm install --name mychart-master charts/mychart
helm install --name mychart-mybranch charts/mychart